### PR TITLE
Preserve stepId to point the right step

### DIFF
--- a/src/Resources/public/gtm.enhancedEcommerce.checkout.js
+++ b/src/Resources/public/gtm.enhancedEcommerce.checkout.js
@@ -11,6 +11,7 @@
     if (!checkoutStepsConfiguration.steps.hasOwnProperty(stepId)) continue;
 
     checkoutStepsConfiguration.steps[stepId].forEach(function BindStep(conf) {
+      conf.stepId = stepId;
       $(conf.selector).on(conf.event, function () {
         var option = null;
 
@@ -21,7 +22,7 @@
           option = window[conf.option].call(this);
         }
 
-        enhancedEcommerceTrackCheckoutOption(stepId, option);
+        enhancedEcommerceTrackCheckoutOption(conf.stepId, option);
       });
     });
   }


### PR DESCRIPTION
While adding more events for the same stepId I spot a bug on the `stepId` variable.
`stepId` is a closure for the bind function so the variable will always get the value of the highest stepId and put the event value to the wrong step ...