### PR TITLE
Adjust bundle notation while referencing templates

### DIFF
--- a/src/Resources/views/ProductDetail/variants.html.twig
+++ b/src/Resources/views/ProductDetail/variants.html.twig
@@ -1,5 +1,5 @@
 <script type="text/javascript">
     {%- for variant in settings.resources.toArray -%}
-        {% include 'SyliusGtmEnhancedEcommercePlugin:ProductDetail:_variant.html.twig' with {'product': variant, 'loop': loop} only %}
+        {% include '@SyliusGtmEnhancedEcommercePlugin/ProductDetail/_variant.html.twig' with {'product': variant, 'loop': loop} only %}
     {%- endfor -%}
 </script>

--- a/src/Resources/views/ProductImpressions/products.html.twig
+++ b/src/Resources/views/ProductImpressions/products.html.twig
@@ -2,6 +2,6 @@
     var productListType = window.productListType || (window.productListType = 'Category Product List');
 
     {%- for product in settings.products -%}
-        {% include 'SyliusGtmEnhancedEcommercePlugin:ProductImpressions:_product.html.twig' with {'product': product, 'loop': loop} only %}
+        {% include '@SyliusGtmEnhancedEcommercePlugin/ProductImpressions/_product.html.twig' with {'product': product, 'loop': loop} only %}
     {%- endfor -%}
 </script>


### PR DESCRIPTION
Hi!
As reported [here](https://github.com/Sylius/SyliusThemeBundle/blob/master/UPGRADE.md#referencing-templates) the new SyliusThemeBundle has removed support for bundle notation while referencing templates. This PR will fix the problem.