### PR TITLE
Adjust bundle notation while referencing templates in services

### DIFF
--- a/src/Resources/config/features/cart.yml
+++ b/src/Resources/config/features/cart.yml
@@ -7,13 +7,13 @@ services:
     sylius.google_tag_manager_enhanced_ecommerce.cart.block_event_listener.sylius.shop.product.show.before_add_to_cart:
         class: Sylius\Bundle\UiBundle\Block\BlockEventListener
         arguments:
-            - 'SyliusGtmEnhancedEcommercePlugin::Cart/product_show.html.twig'
+            - '@@SyliusGtmEnhancedEcommercePlugin/Cart/product_show.html.twig'
         tags:
             - { name: kernel.event_listener, event: sonata.block.event.sylius.shop.product.show.before_add_to_cart, method: onBlockEvent }
 
     sylius.google_tag_manager_enhanced_ecommerce.cart.block_event_listener.layout.javascripts:
         class: Sylius\Bundle\UiBundle\Block\BlockEventListener
         arguments:
-            - 'SyliusGtmEnhancedEcommercePlugin::Cart/javascripts.html.twig'
+            - '@@SyliusGtmEnhancedEcommercePlugin/Cart/javascripts.html.twig'
         tags:
             - { name: kernel.event_listener, event: sonata.block.event.sylius.shop.layout.javascripts, method: onBlockEvent }

--- a/src/Resources/config/features/checkout.yml
+++ b/src/Resources/config/features/checkout.yml
@@ -23,6 +23,6 @@ services:
     sylius.google_tag_manager_enhanced_ecommerce.checkout.block_event_listener.layout.javascripts:
         class: Sylius\Bundle\UiBundle\Block\BlockEventListener
         arguments:
-            - 'SyliusGtmEnhancedEcommercePlugin::Checkout/javascripts.html.twig'
+            - '@@SyliusGtmEnhancedEcommercePlugin/Checkout/javascripts.html.twig'
         tags:
             - { name: kernel.event_listener, event: sonata.block.event.sylius.shop.layout.javascripts, method: onBlockEvent }

--- a/src/Resources/config/features/product_clicks.yml
+++ b/src/Resources/config/features/product_clicks.yml
@@ -7,6 +7,6 @@ services:
     sylius.google_tag_manager_enhanced_ecommerce.product_clicks.block_event_listener.layout.javascripts:
         class: Sylius\Bundle\UiBundle\Block\BlockEventListener
         arguments:
-            - 'SyliusGtmEnhancedEcommercePlugin::ProductClicks/javascripts.html.twig'
+            - '@@SyliusGtmEnhancedEcommercePlugin/ProductClicks/javascripts.html.twig'
         tags:
             - { name: kernel.event_listener, event: sonata.block.event.sylius.shop.layout.javascripts, method: onBlockEvent }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -36,7 +36,7 @@ services:
     sylius.google_tag_manager.enhanced_ecommerce_tracking.global.listener.sylius.shop.layout.head:
         class: Sylius\Bundle\UiBundle\Block\BlockEventListener
         arguments:
-            - 'SyliusGtmEnhancedEcommercePlugin::Global/head.html.twig'
+            - '@@SyliusGtmEnhancedEcommercePlugin/Global/head.html.twig'
         tags:
             - { name: kernel.event_listener, event: sonata.block.event.sylius.shop.layout.head, method: onBlockEvent }
 


### PR DESCRIPTION
Hi!
As reported [here](https://github.com/Sylius/SyliusThemeBundle/blob/master/UPGRADE.md#referencing-templates) the new SyliusThemeBundle has removed support for bundle notation while referencing templates. This PR will fix the problem also in the service arguments.