### PR TITLE
Add compatibility with Symfony 5

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,9 +12,8 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-
-        $rootNode = $treeBuilder->root('sylius_gtm_enhanced_ecommerce');
+        $treeBuilder = new TreeBuilder('sylius_gtm_enhanced_ecommerce');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/EventListener/CheckoutStepListener.php
+++ b/src/EventListener/CheckoutStepListener.php
@@ -6,7 +6,8 @@ use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Resolver\CheckoutStepResolverIn
 use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\CheckoutStepInterface;
 use Sylius\Bundle\CoreBundle\Controller\OrderController;
 use Sylius\Component\Order\Context\CartContextInterface;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+
 
 /**
  * Class CheckoutStepListener
@@ -46,9 +47,9 @@ final class CheckoutStepListener
     }
 
     /**
-     * @param FilterControllerEvent $event
+     * @param ControllerEvent $event
      */
-    public function onKernelController(FilterControllerEvent $event): void
+    public function onKernelController(ControllerEvent $event): void
     {
         $controller = $event->getController();
 

--- a/src/EventListener/ThankYouListener.php
+++ b/src/EventListener/ThankYouListener.php
@@ -6,7 +6,7 @@ use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\AddTransactionInterf
 use Sylius\Bundle\CoreBundle\Controller\OrderController;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 
 /**
  * Class ThankYouListener
@@ -39,9 +39,9 @@ final class ThankYouListener
     }
 
     /**
-     * @param FilterControllerEvent $event
+     * @param ControllerEvent $event
      */
-    public function onKernelController(FilterControllerEvent $event): void
+    public function onKernelController(ControllerEvent $event): void
     {
         $controller = $event->getController();
 


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
Removed use of class FilterControllerEvent which deprecated from Symfony 4.3.