### PR TITLE
Only send a productDetail for the first variant of the product

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade
 
+Upgrade v1.0.0 -> 1.1.0
+-----------------------
+
+As we need to track only the first variant on product show page, ProductDetail twig directory has been refactored
+* `ProductDetail/variants.html.twig` renamed to `ProductDetail/variant.html.twig`
+* `ProductDetail/_variant.html.twig` is removed
+
 Upgrade v0.7.0 -> v0.8.0
 ------------------------
 

--- a/src/Resources/config/features/product_detail_impressions.yml
+++ b/src/Resources/config/features/product_detail_impressions.yml
@@ -21,7 +21,7 @@ services:
     sylius.google_tag_manager.enhanced_ecommerce_tracking.product_detail.listener.product.show.after_product_header:
         class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\EventListener\ProductShowBlockAfterProductHeaderListener
         arguments:
-            - '@@SyliusGtmEnhancedEcommercePlugin/ProductDetail/variants.html.twig'
+            - '@@SyliusGtmEnhancedEcommercePlugin/ProductDetail/variant.html.twig'
             - '@sylius.google_tag_manager.enhanced_ecommerce.tracking.resolver.product_detail_impression_data'
         tags:
             - { name: kernel.event_listener, event: sonata.block.event.sylius.shop.product.show.after_product_header, method: onProductShow }

--- a/src/Resources/views/ProductDetail/_variant.html.twig
+++ b/src/Resources/views/ProductDetail/_variant.html.twig
@@ -1,8 +1,0 @@
-{# @var product \StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Object\ProductDetail #}
-productDetails.push({
-    'name': '{{ product.name }}',
-    'id': '{{ product.id }}',
-    'price': {{ product.price }},
-    'category': '{{ product.category }}',
-    'variant': '{{ product.variant }}'
-});

--- a/src/Resources/views/ProductDetail/variant.html.twig
+++ b/src/Resources/views/ProductDetail/variant.html.twig
@@ -1,0 +1,10 @@
+{% set product = settings.resources.toArray|first %}
+<script type="text/javascript">
+    productDetails.push({
+        'name': '{{ product.name }}',
+        'id': '{{ product.id }}',
+        'price': {{ product.price }},
+        'category': '{{ product.category }}',
+        'variant': '{{ product.variant }}'
+    });
+</script>

--- a/src/Resources/views/ProductDetail/variants.html.twig
+++ b/src/Resources/views/ProductDetail/variants.html.twig
@@ -1,5 +1,0 @@
-<script type="text/javascript">
-    {%- for variant in settings.resources.toArray -%}
-        {% include '@SyliusGtmEnhancedEcommercePlugin/ProductDetail/_variant.html.twig' with {'product': variant, 'loop': loop} only %}
-    {%- endfor -%}
-</script>


### PR DESCRIPTION
Google Analytics calculate more KPI from the "product detail impressions" like : 

- Product view / add to card rate
- Product view / buyed rate

If we send one productDetails event per variant as it done now, these data are wrongfully calculate

So we need to only dispatch the productDetail event for first variant showed on product page. 

Resolve the #90 issue
