### PR TITLE
Fix type for call on ProductDetail::setCategory

### DIFF
--- a/src/Resolver/ProductDetailImpressionDataResolver.php
+++ b/src/Resolver/ProductDetailImpressionDataResolver.php
@@ -71,7 +71,7 @@ final class ProductDetailImpressionDataResolver implements ProductDetailImpressi
         $vo->setId($this->productIdentifierHelper->getProductIdentifier($product));
         $vo->setName($product->getName());
         $vo->setPrice($this->getPrice($productVariant));
-        $vo->setCategory(null !== $product->getMainTaxon() ? $product->getMainTaxon()->getName() : null);
+        $vo->setCategory(null !== $product->getMainTaxon() ? $product->getMainTaxon()->getName() : '');
         $vo->setVariant($productVariant->getCode());
 
         return $vo;


### PR DESCRIPTION
Fix Argument 1 passed to StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Object\ProductDetail::setCategory() must be of the type string form ProductDetailImpressionDataResolve

See issue #133 

I think defaulting it as empty string is a suitable solution, as it is done on other places, see https://github.com/stefandoorn/sylius-google-tag-manager-enhanced-ecommerce-plugin/commit/98766cb4950900f396d17f0ca2b28d9a0e7a7483#diff-24532af58cc19d7b15ee3ffd8fb46771cc3402ab61916ed4eadc9dcb5623a846R29 for example